### PR TITLE
Release task

### DIFF
--- a/src/main/groovy/io/ehdev/version/ReleaseTask.groovy
+++ b/src/main/groovy/io/ehdev/version/ReleaseTask.groovy
@@ -4,9 +4,13 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
 class ReleaseTask extends DefaultTask {
+    public ReleaseTask() {
+        description = "Make the build a release version"  
+        group = "build"  
+    }
 
     @TaskAction
     def markBuildAsRelease() {
-        Version.releaseBuild = true;
+        project.version.releaseBuild = true;
     }
 }

--- a/src/main/groovy/io/ehdev/version/SemanticVersionPlugin.groovy
+++ b/src/main/groovy/io/ehdev/version/SemanticVersionPlugin.groovy
@@ -7,5 +7,6 @@ class SemanticVersionPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         project.setVersion(new Version())
+        project.tasks.create('release', ReleaseTask)
     }
 }

--- a/src/test/groovy/io/ehdev/version/SemanticVersionPluginTest.groovy
+++ b/src/test/groovy/io/ehdev/version/SemanticVersionPluginTest.groovy
@@ -31,9 +31,20 @@ public class SemanticVersionPluginTest {
     }
 
     @Test
-    public void testThatAfterReleaseIsCalledWillNotHaveSnapshot() throws Exception {
+    public void testThatAfterReleaseBuildIsSetWillNotHaveSnapshot() throws Exception {
         project.apply plugin: 'com.github.ethankhall.semantic-versioning'
         project.version.with { major = 1; minor= 2; patch = 3; releaseBuild=true}
         assertThat(project.version.toString()).isEqualToIgnoringCase("1.2.3")
     }
+    
+    @Test
+    public void testThatAfterReleaseTaskIsCalledWillNotHaveSnapshot() throws Exception {
+        project.apply plugin: 'com.github.ethankhall.semantic-versioning'
+        project.version.with { major = 1; minor= 2; patch = 3}
+        assertThat(project.version.toString()).isEqualToIgnoringCase("1.2.3-SNAPSHOT")
+        def releaseTask = project.tasks.findByName('release')
+        releaseTask.actions.each {action -> action.execute(releaseTask)}
+        assertThat(project.version.toString()).isEqualToIgnoringCase("1.2.3")
+    }
+    
 }


### PR DESCRIPTION
The release task was put out of order by the Dec. 29 2014 commit.
This PR reintroduces the release task without breaking the current  contract.
